### PR TITLE
Optimize JitPack build to prevent timeout

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,4 @@
 jdk:
   - openjdk11
 install:
-  - ./gradlew clean :coralogixlogger:assembleRelease :coralogixlogger:publishToMavenLocal --stacktrace
+  - ./gradlew :coralogixlogger:build :coralogixlogger:publishToMavenLocal -x test -x lint

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,4 @@
 jdk:
   - openjdk11
 install:
-  - ./gradlew :coralogixlogger:build :coralogixlogger:publishToMavenLocal -x test -x lint
+  - ./gradlew :coralogixlogger:assembleRelease :coralogixlogger:publishToMavenLocal -x test -x lint


### PR DESCRIPTION
- Build only :coralogixlogger module (not app) to reduce build time
- Skip tests and lint during JitPack build (-x test -x lint)
- Fix: v1.2.0 was timing out during artifact collection phase
- v1.1.3 succeeded with same config but was faster