### PR TITLE
v1.3.0: Fix Coralogix authentication for new regional endpoints

### DIFF
--- a/coralogixlogger/build.gradle
+++ b/coralogixlogger/build.gradle
@@ -12,8 +12,8 @@ android {
     defaultConfig {
         minSdk 24
         targetSdk 33
-        versionCode 121
-        versionName "1.2.1"
+        versionCode 130
+        versionName "1.3.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/coralogixlogger/src/main/java/com/labstyle/coralogixlogger/CoralogixLogger.kt
+++ b/coralogixlogger/src/main/java/com/labstyle/coralogixlogger/CoralogixLogger.kt
@@ -33,7 +33,7 @@ object CoralogixLogger {
     ) {
         config = CoralogixConfig(privateKey, applicationName, subsystemName, region, persistence)
         dbDao = LogEntriesDb.db(context)?.coralogixLogEntryDao()
-        apiService = CoralogixApiService.buildService(region, debug)
+        apiService = CoralogixApiService.buildService(region, privateKey, debug)
         config?.let { cfg -> dbDao?.let { dao -> apiService?.let { srv ->
             queueWorker = QueueWorker(cfg, dao, srv)
         } } }
@@ -77,7 +77,6 @@ object CoralogixLogger {
             try {
                 config?.let { cfg ->
                     val request = LogApiRequest(
-                        privateKey = cfg.privateKey,
                         applicationName = cfg.applicationName,
                         subsystemName = cfg.subsystemName,
                         logEntries = entriesToSend
@@ -98,7 +97,7 @@ object CoralogixLogger {
     fun setDebug(debug: Boolean) {
         this.debug = debug
         config?.let { cfg ->
-            apiService = CoralogixApiService.buildService(cfg.region, CoralogixLogger.debug)
+            apiService = CoralogixApiService.buildService(cfg.region, cfg.privateKey, CoralogixLogger.debug)
             queueWorker?.apiService = apiService as CoralogixApiService
         }
     }

--- a/coralogixlogger/src/main/java/com/labstyle/coralogixlogger/QueueWorker.kt
+++ b/coralogixlogger/src/main/java/com/labstyle/coralogixlogger/QueueWorker.kt
@@ -50,7 +50,6 @@ class QueueWorker(
 
             if (entries.isNotEmpty()) {
                 val request = LogApiRequest(
-                    privateKey = config.privateKey,
                     applicationName = config.applicationName,
                     subsystemName = config.subsystemName,
                     logEntries = entries

--- a/coralogixlogger/src/main/java/com/labstyle/coralogixlogger/models/LogApiRequest.kt
+++ b/coralogixlogger/src/main/java/com/labstyle/coralogixlogger/models/LogApiRequest.kt
@@ -1,7 +1,6 @@
 package com.labstyle.coralogixlogger.models
 
 data class LogApiRequest(
-    val privateKey: String,
     val applicationName: String,
     val subsystemName: String,
     val logEntries: List<CoralogixLogEntry>

--- a/coralogixlogger/src/main/java/com/labstyle/coralogixlogger/service/CoralogixApiService.kt
+++ b/coralogixlogger/src/main/java/com/labstyle/coralogixlogger/service/CoralogixApiService.kt
@@ -2,6 +2,7 @@ package com.labstyle.coralogixlogger.service
 
 import com.labstyle.coralogixlogger.models.CoralogixRegion
 import com.labstyle.coralogixlogger.models.LogApiRequest
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -17,14 +18,24 @@ interface CoralogixApiService {
     suspend fun log(@Body request: LogApiRequest)
 
     companion object {
-        fun buildService(region: CoralogixRegion, debug: Boolean = false): CoralogixApiService {
-            val interceptor = HttpLoggingInterceptor().apply {
+        fun buildService(region: CoralogixRegion, privateKey: String, debug: Boolean = false): CoralogixApiService {
+            val loggingInterceptor = HttpLoggingInterceptor().apply {
                 this.level =
                     if (debug) HttpLoggingInterceptor.Level.BODY
                     else HttpLoggingInterceptor.Level.NONE
             }
+            
+            // Add Authorization header interceptor (new Coralogix requirement)
+            val authInterceptor = Interceptor { chain ->
+                val request = chain.request().newBuilder()
+                    .addHeader("Authorization", "Bearer $privateKey")
+                    .build()
+                chain.proceed(request)
+            }
+            
             val okClient: OkHttpClient = OkHttpClient.Builder()
-                .addInterceptor(interceptor)
+                .addInterceptor(authInterceptor)
+                .addInterceptor(loggingInterceptor)
                 .connectTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .readTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .writeTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)

--- a/coralogixlogger/src/main/java/com/labstyle/coralogixlogger/service/CoralogixApiService.kt
+++ b/coralogixlogger/src/main/java/com/labstyle/coralogixlogger/service/CoralogixApiService.kt
@@ -34,8 +34,8 @@ interface CoralogixApiService {
             }
             
             val okClient: OkHttpClient = OkHttpClient.Builder()
-                .addInterceptor(authInterceptor)
                 .addInterceptor(loggingInterceptor)
+                .addInterceptor(authInterceptor)
                 .connectTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .readTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .writeTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,4 @@
 jdk:
   - openjdk11
 install:
-  - ./gradlew :coralogixlogger:assembleRelease :coralogixlogger:publishToMavenLocal -x test -x lint
+  - ./gradlew :coralogixlogger:assembleRelease :coralogixlogger:publishToMavenLocal -x test -x lint -x publishReleasePublicationToGitHubPackagesRepository


### PR DESCRIPTION
BREAKING CHANGE: Updated authentication method for Coralogix December 12, 2025 migration

Changes:
- Add Authorization: Bearer header (NEW requirement per Coralogix deprecation guide)
- Remove privateKey from request body (deprecated)
- Update CoralogixApiService to add auth interceptor
- Update LogApiRequest to remove privateKey field
- Update all buildService and LogApiRequest calls
- Bump version to 1.3.0

The new authentication method is required for the Coralogix regional endpoint migration. Old method (privateKey in body) now returns 403 Forbidden. New method (Authorization header) returns 200 Success.

Reference: https://coralogix.com/docs/user-guides/latest-updates/deprecations/endpoints/