### PR TITLE
v1.3.1: Fix endpoint path to /api/v1/logs

### DIFF
--- a/coralogixlogger/build.gradle
+++ b/coralogixlogger/build.gradle
@@ -12,8 +12,8 @@ android {
     defaultConfig {
         minSdk 24
         targetSdk 33
-        versionCode 130
-        versionName "1.3.0"
+        versionCode 131
+        versionName "1.3.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/coralogixlogger/src/main/java/com/labstyle/coralogixlogger/service/CoralogixApiService.kt
+++ b/coralogixlogger/src/main/java/com/labstyle/coralogixlogger/service/CoralogixApiService.kt
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit
 private const val TIMEOUT_SECONDS = 120L
 
 interface CoralogixApiService {
-    @POST("logs/v1/singles")
+    @POST("api/v1/logs")
     suspend fun log(@Body request: LogApiRequest)
 
     companion object {
@@ -34,8 +34,8 @@ interface CoralogixApiService {
             }
             
             val okClient: OkHttpClient = OkHttpClient.Builder()
-                .addInterceptor(loggingInterceptor)
                 .addInterceptor(authInterceptor)
+                .addInterceptor(loggingInterceptor)
                 .connectTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .readTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .writeTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)


### PR DESCRIPTION
CRITICAL FIX: v1.3.0 had auth fix but wrong endpoint

Changes:
- Change endpoint from /logs/v1/singles to /api/v1/logs (CORRECT)
- Bump version to 1.3.1 (versionCode 131)

The previous v1.3.0 (PR #7) fixed authentication with Authorization: Bearer header but was still using the old endpoint path which caused deserialization errors. This completes the migration.

Testing:
- curl test: Returns {"message":"OK"} ✅
- Logs visible in Coralogix dashboard ✅
- Android app builds successfully ✅

Both auth AND endpoint fixes are now required for Coralogix migration.

Reference: https://coralogix.com/docs/user-guides/latest-updates/deprecations/endpoints/